### PR TITLE
Add: time diffing utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 
 const utils = require('./utils');
 
-module.exports = (time, smallest, digits) => {
+function prettyTime(time, smallest, digits) {
   const isNumber = /^[0-9]+$/.test(time);
   if (!isNumber && !Array.isArray(time)) {
     throw new TypeError('expected an array or number in nanoseconds');
@@ -33,7 +33,7 @@ module.exports = (time, smallest, digits) => {
 
     if (smallest && utils.isSmallest(uom, smallest)) {
       inc = utils.round(inc, digits);
-      if (prev && (inc === (prev / step))) --inc;
+      if (prev && (inc === (prev / step)))--inc;
       res += inc + uom;
       return res.trim();
     }
@@ -53,4 +53,16 @@ module.exports = (time, smallest, digits) => {
   }
 
   return res.trim();
+}
+
+prettyTime.start = function() {
+  const startTime = process.hrtime();
+  return {
+    end: unit => prettyTime(process.hrtime(startTime), unit)
+  };
 };
+
+const timeStart = prettyTime.start();
+prettyTime.uptime = unit => timeStart.end(unit);
+
+module.exports = prettyTime;

--- a/test.js
+++ b/test.js
@@ -14,7 +14,19 @@ describe('pretty', function() {
     assert.throws(() => pretty([0,1,2]), /expected an array from process\.hrtime\(\)/);
   });
 
-  it('should support hrtime:', function() {
+  it('should pretty print time differences', done => {
+    const t = pretty.start();
+    setTimeout(() => {
+      try {
+        assert(/^[0-9]+s$/.test(t.end()));
+        done();
+      } catch (err) {
+        done(err);
+      }
+    }, 1100)
+  });
+
+  it('should support hrtime:', function () {
     const start = process.hrtime();
     const time = process.hrtime(start);
     assert(typeof pretty(time) === 'string');


### PR DESCRIPTION
Hi, there!

This PR adds two convenience methods: `prettyTime.start()` and `prettyTime.uptime()`.

`prettyTime.start()` returns a single object with the signature `{ end(unit: string): string }`. The end method will return the time between the call to `start()` and `end()` prettified - ideal for timing.

`prettyTime.uptime()` returns the prettified time difference from the time that the module was `require()`-d into the runtime and the call to `uptime()` - ideal for CLIs to check time from start to end or APIs for server uptime.